### PR TITLE
module-info.java 제외

### DIFF
--- a/rule-config/naver-checkstyle-rules.xml
+++ b/rule-config/naver-checkstyle-rules.xml
@@ -425,4 +425,9 @@ The following rules in the Naver coding convention cannot be checked by this con
 		<property name="optional" value="true"/>
 	</module>
 
+	<!--- Exclude module-info.java -->
+	<module name="BeforeExecutionExclusionFileFilter">
+		<property name="fileNamePattern" value="module\-info\.java$"/>
+	</module>
+
 </module>


### PR DESCRIPTION
- module-info.java 를 제외합니다.
- https://github.com/checkstyle/checkstyle/issues/6570
- https://checkstyle.org/config_filefilters.html#BeforeExecutionExclusionFileFilter_Examples

---

- :checkstyleMain 실패
<img width="1192" alt="스크린샷 2021-01-06 오전 2 52 45" src="https://user-images.githubusercontent.com/5206572/103681136-729fde80-4fca-11eb-9e3f-a0ae952b9ea4.png">


