### PR TITLE
Update naver-checkstyle-rules.xml

### DIFF
--- a/rule-config/naver-checkstyle-rules.xml
+++ b/rule-config/naver-checkstyle-rules.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!DOCTYPE module PUBLIC
 		"-//Puppy Crawl//DTD Check Configuration 1.3//EN"
-		"http://www.puppycrawl.com/dtds/configuration_1_3.dtd">
+		"https://checkstyle.org/dtds/configuration_1_3.dtd">
 
 <!-- Naver coding convention for Java (version 1.2)  -->
 <!-- This rule file requires Checkstyle version 8.24 or above. -->


### PR DESCRIPTION
IntelliJ IDEA 2022.3 (Ultimate Edition)

intellij 에서 cannot initialize module SuppressionFilter error가 발생하여 도메인 교체 후 해결 되었습니다.

issue: #6 